### PR TITLE
Add extra jsdoc3 parameters

### DIFF
--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMojo.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMojo.java
@@ -55,6 +55,13 @@ public class JsDocMojo extends AbstractMojo {
     private File tutorialsDirectory;
 
     /**
+     * if a configuration file will be provided to jsdoc.
+     * see: http://usejsdoc.org/about-configuring-jsdoc.html#configuration-file
+     */
+    @Parameter(required = false)
+    private File configFile;
+
+    /**
      * Execute the jsdoc3 Main.
      *
      * @throws MojoExecutionException If parameters aren't correct or if an error is occurred while running jsdoc.
@@ -78,6 +85,7 @@ public class JsDocMojo extends AbstractMojo {
         builder.withTempDirectory(workingDirectory);
         builder.withJsDocDirectory(jsDoc3Dir);
         builder.withTutorialsDirectory(tutorialsDirectory);
+        builder.withConfigFile(configFile);
 
         try {
             final TaskContext taskContext = builder.build();

--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocTask.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocTask.java
@@ -51,6 +51,11 @@ final class JsDocTask implements Task {
             arguments.add("-r");
         }
 		
+        if (context.getConfigFile() != null) {
+            arguments.add("-c");
+            arguments.add(context.getConfigFile().toString());
+        }
+
         if (context.isIncludePrivate()) {
             arguments.add("-p");
         }

--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/TaskContext.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/TaskContext.java
@@ -27,6 +27,9 @@ public final class TaskContext {
     /** a temp dir for scratch files */
     private final File tempDir;
 
+    /** The path to the configuration file. Default: jsdoc __dirname + /conf.json */
+    private final File configFile;
+
     /** if jsdoc should run in debug mode */
     private final boolean debug;
 
@@ -43,24 +46,27 @@ public final class TaskContext {
     /**
      * Private constructor.
      *
-     * @param sourceDir the source dir.
-     * @param outputDir the output dir.
-     * @param jsDocDir  the jsdoc dir.
-     * @param tempDir   the temp dir.
-     * @param debug     if debug mode should be used.
-     * @param recursive if the jsdoc task should recursively look for jsfiles.
+     * @param sourceDir      the source dir.
+     * @param outputDir      the output dir.
+     * @param jsDocDir       the jsdoc dir.
+     * @param jsDocDir       the tutorials dir.
+     * @param configFile     the configuration file (i.e. conf.json).
+     * @param tempDir        the temp dir.
+     * @param debug          if debug mode should be used.
+     * @param recursive      if the jsdoc task should recursively look for jsfiles.
      * @param includePrivate if private symbols should be included.
-     * @param log The logger.
+     * @param log            The logger.
      */
-    TaskContext(Collection<File> sourceDir, File outputDir, File jsDocDir, File tutorialsDirectory,
+    TaskContext(Collection<File> sourceDir, File outputDir, File jsDocDir, File tutorialsDirectory, File configFile,
                 File tempDir, boolean debug, boolean recursive, boolean includePrivate, Log log) {
-        this.sourceDir = sourceDir;
-        this.jsDocDir  = jsDocDir;
-        this.outputDir = outputDir;
+        this.sourceDir  = sourceDir;
+        this.jsDocDir   = jsDocDir;
+        this.outputDir  = outputDir;
         this.tutorialsDirectory = tutorialsDirectory;
-        this.tempDir   = tempDir;
-        this.debug     = debug;
-        this.recursive = recursive;
+        this.configFile = configFile;
+        this.tempDir    = tempDir;
+        this.debug      = debug;
+        this.recursive  = recursive;
         this.includePrivate = includePrivate;
         this.log = log;
     }
@@ -99,6 +105,15 @@ public final class TaskContext {
      */
     public File getTutorialsDirectory() {
         return tutorialsDirectory;
+    }
+
+    /**
+     * Get the configuration file (i.e. conf.json).
+     *
+     * @return The configuration file.
+     */
+    public File getConfigFile() {
+        return configFile;
     }
 
     /**
@@ -159,6 +174,8 @@ public final class TaskContext {
 
         private File jsDocDirectory;
 
+        private File configFile;
+
         private File tempDirectory;
 
         private boolean debug = false;
@@ -185,6 +202,11 @@ public final class TaskContext {
 
         public Builder withJsDocDirectory(final File jsDocDirectory) {
             this.jsDocDirectory = jsDocDirectory;
+            return this;
+        }
+
+        public Builder withConfigFile(final File configFile) {
+            this.configFile = configFile;
             return this;
         }
 
@@ -253,7 +275,7 @@ public final class TaskContext {
 
             // this is getting a little out of hand...
             return new TaskContext(sourceRoots,
-                    outputDirectory, jsDocDirectory, tutorialsDirectory,
+                    outputDirectory, jsDocDirectory, tutorialsDirectory, configFile,
                     tempDirectory, debug, recursive, includePrivate, log);
         }
     }

--- a/jsdoc3-maven-plugin/src/test/java/com/github/phasebash/jsdoc3/maven/tasks/CopyTaskTest.java
+++ b/jsdoc3-maven-plugin/src/test/java/com/github/phasebash/jsdoc3/maven/tasks/CopyTaskTest.java
@@ -23,7 +23,7 @@ public class CopyTaskTest {
     @Test
     public void testCopyDirDoesntExist() {
         final File tempFile = new File(temporaryFolder.getRoot(), "rooty");
-        final TaskContext context = new TaskContext(null, null, null, null, tempFile, false, true, false, null);
+        final TaskContext context = new TaskContext(null, null, null, null, null, tempFile, false, true, false, null);
         copyTask.execute(context);
         Assert.assertTrue("jsdoc.zip should exist.", new File(tempFile, "jsdoc.zip").exists());
     }
@@ -32,7 +32,7 @@ public class CopyTaskTest {
     public void testCopyDirExists() {
         final File tempFile = new File(temporaryFolder.getRoot(), "rooty");
         tempFile.mkdirs();
-        final TaskContext context = new TaskContext(null, null, null, null, tempFile, false, true, false, null);
+        final TaskContext context = new TaskContext(null, null, null, null, null, tempFile, false, true, false, null);
         copyTask.execute(context);
         Assert.assertTrue("jsdoc.zip should exist.", new File(tempFile, "jsdoc.zip").exists());
     }
@@ -40,7 +40,7 @@ public class CopyTaskTest {
     @Test
     public void testCopyFileSize() {
         final File tempFile = new File(temporaryFolder.getRoot(), "rooty");
-        final TaskContext context = new TaskContext(null, null, null, null, tempFile, false, true, false, null);
+        final TaskContext context = new TaskContext(null, null, null, null, null, tempFile, false, true, false, null);
         copyTask.execute(context);
         Assert.assertTrue("jsdoc.zip should exist.", new File(tempFile, "jsdoc.zip").exists());
 


### PR DESCRIPTION
Hi,

I needed to pass some config to jsdoc3, so I needed the '`-c`' option.  These changes seem to work for me.

E.g. my `conf.json` uses an alternate template, and turns off output of source files ([pretty print](https://github.com/jsdoc3/jsdoc/issues/208#issuecomment-9621558)):

```
{
    "opts": {
        "template": "jsdoc/jsdoc3-templates/my_first_template",
        "templates": {
            "default": {
                "outputSourceFiles": false
            }
        }
    }
}
```

And my pom:

```
                <configFile>jsdoc/conf.json</configFile>
```

Both the path to `conf.json` and the path to the template are relative to my `pom.xml`.
