### PR TITLE
Add explicit dependency for doxia-sink-api 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.maven.doxia</groupId>
+                <artifactId>doxia-sink-api</artifactId>
+                <version>1.2</version>
+            </dependency>
+
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons.io.version}</version>


### PR DESCRIPTION
Hi there,

Me again!

I'm still using your plugin in the build phase rather than the new reporting phase functionality. Version 1.0.5 works great on Maven 2.2.1, but blows up with the following error on Maven 3. I tried on both Maven 3.0.3 and 3.1.0.

```
[ERROR] Failed to execute goal com.github.phasebash:jsdoc3-maven-plugin:1.0.6-SNAPSHOT:jsdoc3 (default-cli) on project biscuit: Execution default-cli of goal com.github.phasebash:jsdoc3-maven-plugin:1.0.6-SNAPSHOT:jsdoc3 failed: A required class was missing while executing com.github.phasebash:jsdoc3-maven-plugin:1.0.6-SNAPSHOT:jsdoc3: org/apache/maven/doxia/sink/SinkEventAttributes
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>com.github.phasebash:jsdoc3-maven-plugin:1.0.6-SNAPSHOT
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
...
[ERROR] urls[6] = file:/workspace/mvn/repo/org/apache/maven/doxia/doxia-sink-api/1.0/doxia-sink-api-1.0.jar
...
```

This appears to be the same as this issue and corresponding fix:
https://github.com/marcelmay/maven-rbc-plugin/issues/6
https://github.com/marcelmay/maven-rbc-plugin/commit/9c3b8dd3334e20d8073a19d7c728bf2eff065f74

As such I've made the same change to your plugin's POM and rebuilt. It appears to fix the problem.

I'd take this pull request with a pinch of salt, though - I have no idea if it's the correct solution. I also don't really need this fix, so no worries if you don't want to put it in. :)

Thanks again for a useful plugin.
