### PR TITLE
Add parameter to skip jsdoc generation in maven projects

### DIFF
--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMavenReport.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMavenReport.java
@@ -98,6 +98,13 @@ public class JsDocMavenReport extends AbstractMavenReport {
     @Parameter(required = true, defaultValue = "false")
     private boolean includePrivate;
 
+	/**
+	 * Specifies whether the JSDoc generation should be skipped
+	 */
+	@Parameter( property = "maven.jsdoc.skip", defaultValue = "false" )
+	protected boolean skip;
+		
+	
     @Override
     protected Renderer getSiteRenderer() {
         return siteRenderer;
@@ -117,6 +124,11 @@ public class JsDocMavenReport extends AbstractMavenReport {
     protected void executeReport(Locale locale) throws MavenReportException {
         final Log log = getLog();
 
+		if ( skip ) {
+			log.info( "Skipping jsdoc generation" );
+			return;
+		}
+		
         workingDirectory.mkdirs();
         outputDirectory.mkdirs();
 

--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMojo.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/JsDocMojo.java
@@ -79,6 +79,12 @@ public class JsDocMojo extends AbstractMojo {
     @Parameter(required = false)
     private boolean lenient = false;
 
+	/**
+	 * Specifies whether the JSDoc generation should be skipped
+	 */
+	@Parameter( property = "maven.jsdoc.skip", defaultValue = "false" )
+	protected boolean skip;
+	
     /**
      * Execute the jsdoc3 Main.
      *
@@ -87,7 +93,13 @@ public class JsDocMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException {
         final Log log = getLog();
 
-        workingDirectory.mkdirs();
+		if ( skip )
+		{
+			log.info( "Skipping jsdoc generation" );
+			return;
+		}
+
+		workingDirectory.mkdirs();
         outputDirectory.mkdirs();
 
         final File jsDoc3Dir = new File(workingDirectory, "jsdoc");


### PR DESCRIPTION
Add and take into account a "maven.jsdoc.skip" property that allow to
switch off the generation for some sub projects.
