### PR TITLE
Updating to use JSDoc 3.3.2

### DIFF
--- a/jsdoc3-maven-plugin/pom.xml
+++ b/jsdoc3-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.phasebash.jsdoc</groupId>
         <artifactId>jsdoc3</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jsdoc3-maven-plugin</artifactId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.phasebash.jsdoc</groupId>
             <artifactId>jsdoc3-rhino</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 
@@ -156,7 +156,7 @@
                                              <!--includes="**/*.jar" />-->
                                 <!--</delete>-->
 
-                                <zip destfile="${project.build.directory}/classes/com/github/jsdoc3/jsdoc.zip" basedir="${project.build.directory}/jsdoc3/jsdoc-releases-${jsdoc-release-version}" />
+                                <zip destfile="${project.build.directory}/classes/com/github/jsdoc3/jsdoc.zip" basedir="${project.build.directory}/jsdoc3/jsdoc-releases-${jsdoc-release-major-version}" />
                             </target>
                         </configuration>
                         <goals>

--- a/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocArgumentBuilder.java
+++ b/jsdoc3-maven-plugin/src/main/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocArgumentBuilder.java
@@ -13,7 +13,7 @@ public class JsDocArgumentBuilder {
 
     /** the commonjs module directories to include */
     private static final List<String> MODULES = Collections.unmodifiableList(Arrays.asList(
-            "node_modules", "rhino", "lib", ""
+            "lib", "node_modules", "rhino", ""
     ));
 
     /**
@@ -38,8 +38,6 @@ public class JsDocArgumentBuilder {
         }
 
         arguments.add(replace(new File(basePath, "jsdoc.js").toString()));
-
-        arguments.add("--dirname=" + replace(basePath.toString()));
 
         if (context.isRecursive()) {
             arguments.add("-r");

--- a/jsdoc3-maven-plugin/src/test/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocArgumentBuilderTest.java
+++ b/jsdoc3-maven-plugin/src/test/java/com/github/phasebash/jsdoc3/maven/tasks/JsDocArgumentBuilderTest.java
@@ -47,12 +47,11 @@ public class JsDocArgumentBuilderTest {
     @Test
     public void testMinimalContext() {
         List<String> arguments = builder.build(minimumContext);
-        Assert.assertEquals("number of arguments.", 17, arguments.size());
+        Assert.assertEquals("number of arguments.", 16, arguments.size());
 
         assertClassPath(arguments);
         assertModule(arguments);
         assertJsDocJs(arguments);
-        assertDirName(arguments);
 
         Assert.assertFalse(arguments.contains("-l"));
     }
@@ -83,10 +82,6 @@ public class JsDocArgumentBuilderTest {
         Assert.assertTrue(builder.build(configBuilder.build()).contains("-t"));
     }
 
-    private void assertDirName(List<String> arguments) {
-        Assert.assertEquals("dirname", "--dirname=" + path("/", directory(), JS_DOC_DIR_NAME), arguments.get(13));
-    }
-
     private void assertJsDocJs(List<String> arguments) {
         Assert.assertEquals("jsdoc.js", path("/", directory(), JS_DOC_DIR_NAME, "jsdoc.js"), arguments.get(12));
     }
@@ -102,9 +97,9 @@ public class JsDocArgumentBuilderTest {
 
         String base = directory();
 
-        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "node_modules"), arguments.get(5));
-        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "rhino"), arguments.get(7));
-        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "lib"), arguments.get(9));
+        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "lib"), arguments.get(5));
+        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "node_modules"), arguments.get(7));
+        Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME, "rhino"), arguments.get(9));
         Assert.assertEquals("module dir", osUriBase() + path("/", base, JS_DOC_DIR_NAME), arguments.get(11));
     }
 

--- a/jsdoc3-rhino/pom.xml
+++ b/jsdoc3-rhino/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.phasebash.jsdoc</groupId>
         <artifactId>jsdoc3</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jsdoc3-rhino</artifactId>
@@ -56,7 +56,7 @@
                                 <!--
                                     What is yours is now mine
                                 -->
-                                <unzip src="${project.build.directory}/jsdoc3/jsdoc-releases-${jsdoc-release-version}/rhino/js.jar" dest="${project.build.directory}/classes" />
+                                <unzip src="${project.build.directory}/jsdoc3/jsdoc-releases-${jsdoc-release-major-version}/rhino/js.jar" dest="${project.build.directory}/classes" />
                             </target>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,6 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
--->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -195,6 +194,7 @@
                     </execution>
                 </executions>
             </plugin>
+-->
         </plugins>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,7 @@
 
     <build>
         <plugins>
+<!--
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -179,6 +180,7 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>com.phasebash.jsdoc</groupId>
     <artifactId>jsdoc3</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <name>JsDoc3 Maven Plugin</name>
     <description>A Maven Plugin to Generate JsDoc3 Documentation.</description>
@@ -53,7 +53,8 @@
         <commons-lang-version>2.6</commons-lang-version>
 
         <!--jsdoc versions-->
-        <jsdoc-release-version>3.2</jsdoc-release-version>
+        <jsdoc-release-major-version>3.3</jsdoc-release-major-version>
+        <jsdoc-release-version>3.3.2</jsdoc-release-version>
 
         <!--test versions-->
         <junit-version>4.8.2</junit-version>


### PR DESCRIPTION
Fairly minimal changes; the biggest difference is to remove --dirname, which is no longer supported (nor necessary?).