### PR TITLE
update maven-plugin-plugin to 3.4

### DIFF
--- a/jsdoc3-maven-plugin/pom.xml
+++ b/jsdoc3-maven-plugin/pom.xml
@@ -96,7 +96,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.4</version>
                 <configuration>
                     <goalPrefix>jsdoc3</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>


### PR DESCRIPTION
The used maven-plugin-plugin 3.1 generates a wrong plugin.xml which includes a corrupt help mojo implementation specification: 

`<implementation>HelpMojo</implementation>`

Updating to maven-plugin-plugin to 3.4 fixes this issue an generates:

`<implementation>com.github.phasebash.jsdoc3.maven.HelpMojo</implementation>`

which is correct
